### PR TITLE
Update IntelliJ and Ruby versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.9.21"
-    id("org.jetbrains.intellij") version "1.16.1"
+    id("org.jetbrains.intellij") version "1.17.3"
 }
 
 group = "im.simo.rubymine.sorbetlsp"
@@ -13,11 +13,11 @@ repositories {
 // Configure Gradle IntelliJ Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
-    version.set("2023.3")
+    version.set("2024.1")
     type.set("IU") // Target IDE Platform
 
     plugins.set(listOf(
-            "org.jetbrains.plugins.ruby:233.11799.241"
+            "org.jetbrains.plugins.ruby:241.14494.240"
     ))
 }
 
@@ -32,7 +32,7 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("233")
+        sinceBuild.set("241")
     }
 
     signPlugin {


### PR DESCRIPTION
Fixes https://github.com/simoleone/rubymine-sorbet-lsp/issues/6

⚠️ I assume this makes it incompatible with 2023.x, but I haven't tested.


## Testing
```
./gradlew signPlugin
```

Install `build/distributions/rubymine-sorbet-lsp.zip` from disk

<img width="597" alt="image" src="https://github.com/simoleone/rubymine-sorbet-lsp/assets/1216046/5f3fa89b-b70c-49bf-babb-7b04787cf0c0">

