### PR TITLE
Support 2024.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,11 +13,11 @@ repositories {
 // Configure Gradle IntelliJ Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
-    version.set("2024.1")
+    version.set("2024.2")
     type.set("IU") // Target IDE Platform
 
     plugins.set(listOf(
-            "org.jetbrains.plugins.ruby:241.14494.240"
+            "org.jetbrains.plugins.ruby:242.20224.387"
     ))
 }
 
@@ -32,7 +32,7 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("241")
+        sinceBuild.set("242")
     }
 
     signPlugin {


### PR DESCRIPTION
- Add support for IntelliJ 2024.2
- Similar to: https://github.com/simoleone/rubymine-sorbet-lsp/pull/7
- Fixes: https://github.com/simoleone/rubymine-sorbet-lsp/issues/8

Tested with `./gradelw build` + Install plugin from disk in IntelliJ